### PR TITLE
Fix service timeout functionality

### DIFF
--- a/BTKit.podspec
+++ b/BTKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "BTKit"
-  spec.version      = "0.4.3"
+  spec.version      = "0.4.4"
   spec.summary      = "Hardcoded bluetooth devices API"
   spec.description  = <<-DESC
                         Use to scan for bluetooth devices. Very limited set of devices is available.

--- a/Sources/BTKit/Devices/BTServices.swift
+++ b/Sources/BTKit/Devices/BTServices.swift
@@ -446,8 +446,9 @@ public struct BTKitRuuviNUSService {
                                 result(observer, .failure(error))
                             }
                         }
-                    case .failure:
-                        break
+                    case .failure(let error):
+                        progress?(.failure(error))
+                        result(observer, .failure(error))
                     }
                 }
             case .failure(let error):

--- a/Sources/BTKit/Devices/BTServices.swift
+++ b/Sources/BTKit/Devices/BTServices.swift
@@ -409,8 +409,9 @@ public struct BTKitRuuviNUSService {
                                 result(observer, .failure(error))
                             }
                         }
-                    case .failure:
-                        break
+                    case let .failure(error):
+                        progress?(.failure(error))
+                        result(observer, .failure(error))
                     }
 
                 }


### PR DESCRIPTION
Previousely there was an assumption that service and characteristics will be discovered on request, but it is not the case when battery dies in the beginning of the sync process. 