### PR TITLE
Fix network parser parsable data

### DIFF
--- a/Sources/BTKit/Vendor/Ruuvi/Decoder/iOS/RuuviDecoderiOS.swift
+++ b/Sources/BTKit/Vendor/Ruuvi/Decoder/iOS/RuuviDecoderiOS.swift
@@ -11,7 +11,7 @@ public struct RuuviDecoderiOS: BTDecoder {
         let versionOffset = 7
         let version = Int(data[versionOffset])
         let parsableOffset = 5
-        let parsable = Data(data[parsableOffset...data.count - parsableOffset])
+        let parsable = Data(data[parsableOffset...data.count - 1])
         switch version {
         case 2:
             let ruuvi = parsable.ruuvi2()


### PR DESCRIPTION
For unknown reason I limited parsable data from the right side. Fixed with applying offset only from left side.