### PR TITLE
Implement BTKitForegroundPublisher for Efficient RuuviTag Data Streaming

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "BTKit",
     defaultLocalization: "en",
-    platforms: [.macOS(.v10_15), .iOS(.v10)],
+    platforms: [.macOS(.v10_15), .iOS(.v13)],
     products: [
         .library(
             name: "BTKit",

--- a/Sources/BTKit/Combine/BTForeground+Combine.swift
+++ b/Sources/BTKit/Combine/BTForeground+Combine.swift
@@ -1,0 +1,50 @@
+import Combine
+
+public final class BTKitForegroundPublisher {
+    public lazy var ruuviTag: AnyPublisher<RuuviTag, Never> = {
+        ruuviTagSubject
+            .handleEvents(receiveSubscription: { [weak self] subscription in
+                self?.addSubscriber(subscription)
+            })
+            .eraseToAnyPublisher()
+    }()
+
+    private let foreground: BTForeground
+    private let ruuviTagSubject = PassthroughSubject<RuuviTag, Never>()
+    private var subscriptions = [CombineIdentifier: AnyCancellable]()
+    private var cancelable: ObservationToken?
+
+    public init(foreground: BTForeground) {
+        self.foreground = foreground
+    }
+
+    private func addSubscriber(_ subscription: Subscription) {
+        let cancellable = AnyCancellable { [weak self] in
+            self?.removeSubscriber(subscription.combineIdentifier)
+        }
+        subscriptions[subscription.combineIdentifier] = cancellable
+        if subscriptions.count == 1 {
+            startListening()
+        }
+    }
+
+    private func removeSubscriber(_ id: CombineIdentifier) {
+        subscriptions.removeValue(forKey: id)
+        if subscriptions.isEmpty {
+            stopListening()
+        }
+    }
+
+    private func startListening() {
+        cancelable = foreground.scan(self) { observer, device in
+            if let ruuviTag = device.ruuvi?.tag {
+                observer.ruuviTagSubject.send(ruuviTag)
+            }
+        }
+    }
+
+    private func stopListening() {
+        cancelable?.invalidate()
+        cancelable = nil
+    }
+}

--- a/Sources/BTKit/Devices/BTForeground.swift
+++ b/Sources/BTKit/Devices/BTForeground.swift
@@ -1,6 +1,7 @@
 public struct BTForeground {
     public static let shared = BTForeground()
-    
+    public static let publisher = BTKitForegroundPublisher(foreground: .shared)
+
     let scanner: BTScanner = BTScanneriOS(decoders: [RuuviDecoderiOS()])
     
     public var bluetoothState: BTScannerState { return scanner.bluetoothState }


### PR DESCRIPTION
This pull request introduces the BTKitForegroundPublisher class, a crucial addition to our Bluetooth handling capabilities, particularly focusing on RuuviTag sensor data streaming. This class encapsulates the logic for managing subscriptions to RuuviTag data and controlling the lifecycle of Bluetooth scans in response to subscriber demand.

Usage: 
```swift
BTForeground.publisher.ruuviTag.sink { ruuviTag in
        // Handle RuuviTag data
    }
    .store(in: &cancellables)
```